### PR TITLE
Optimize the configuration file to avoid to intall file failed

### DIFF
--- a/site/help/anaconda.md
+++ b/site/help/anaconda.md
@@ -24,7 +24,11 @@ Then a configuration file named `.condarc` will be created. And you can manually
 
 ``` toml
 channels:
-  - defaults
+  - conda-forge
+  - bioconda
+  - pytorch
+  - nvidia
+  - nodefaults
 show_channel_urls: true
 default_channels:
   - https://mirrors.sustech.edu.cn/anaconda/pkgs/main


### PR DESCRIPTION
I got an unexpected redirection to USTC mirrors when I used the example configuration to install langgraph. I think there is a conflict between the channels' default and the default_channels. I checked with deepseek, got the new configuration, and verified it works.